### PR TITLE
Take the region value that is provided as argument.

### DIFF
--- a/lib/castor/cli.rb
+++ b/lib/castor/cli.rb
@@ -50,7 +50,7 @@ module Castor
           @options['debug'] = debug
         end
 
-        opts.on('-r', 'AWS region (defaults to us-east-1)') do |region|
+        opts.on('-r REGION', 'AWS region (defaults to us-east-1)') do |region|
           @options['region'] = region
         end
 

--- a/lib/castor/version.rb
+++ b/lib/castor/version.rb
@@ -1,3 +1,3 @@
 module Castor
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
 Currently when using the region paramater, @option['region'] gets set to true and not the actual region value
