### PR TITLE
Add option to specify credentials on the command line

### DIFF
--- a/lib/castor/cli.rb
+++ b/lib/castor/cli.rb
@@ -42,6 +42,7 @@ module Castor
 
       aws_config = { region: @config[:region] }
       aws_config[:profile] = @config[:profile] if @config[:profile]
+      aws_config[:credentials] = Aws::Credentials.new(@config[:access_key], @config[:secret_key]) if @config[:access_key]
       Aws.config.update(aws_config)
     end
 

--- a/lib/castor/config.rb
+++ b/lib/castor/config.rb
@@ -35,6 +35,16 @@ module Castor
       :long => '--profile PROFILE',
       :description => 'AWS profile to use in ~/.aws/credentials'
 
+    option :access_key,
+      :short => '-a access_key',
+      :long => '--access-key access_key',
+      :description => 'AWS access key ID. Should be used along with --secret-key'
+
+    option :secret_key,
+      :short => '-s secret_key',
+      :long => '--secret-key secret_key',
+      :description => 'AWS secret access key. Should be used along with --access-key'
+
     option :region,
       :short => '-r REGION',
       :long => '--region REGION',


### PR DESCRIPTION
Alternate option for those of us who don't want to manage ~/.aws/credentials
